### PR TITLE
Allow to directly pass one-hot encoded ground-truth labels

### DIFF
--- a/research/object_detection/builders/dataset_builder.py
+++ b/research/object_detection/builders/dataset_builder.py
@@ -83,7 +83,7 @@ def read_dataset(file_read_func, input_files, config):
   return records_dataset
 
 
-def build(input_reader_config, batch_size=None, transform_input_data_fn=None):
+def build(input_reader_config, batch_size=None, transform_input_data_fn=None, one_hot_encoded_labels=True):
   """Builds a tf.data.Dataset.
 
   Builds a tf.data.Dataset by applying the `transform_input_data_fn` on all
@@ -112,16 +112,13 @@ def build(input_reader_config, batch_size=None, transform_input_data_fn=None):
       raise ValueError('At least one input path must be specified in '
                        '`input_reader_config`.')
 
-    label_map_proto_file = None
-    if input_reader_config.HasField('label_map_path'):
-      label_map_proto_file = input_reader_config.label_map_path
     decoder = tf_example_decoder.TfExampleDecoder(
         load_instance_masks=input_reader_config.load_instance_masks,
         load_multiclass_scores=input_reader_config.load_multiclass_scores,
         instance_mask_type=input_reader_config.mask_type,
-        label_map_proto_file=label_map_proto_file,
         use_display_name=input_reader_config.use_display_name,
-        num_additional_channels=input_reader_config.num_additional_channels)
+        num_additional_channels=input_reader_config.num_additional_channels,
+        one_hot_encoded_labels=one_hot_encoded_labels)
 
     def process_fn(value):
       """Sets up tf graph that decodes, transforms and pads input data."""

--- a/research/object_detection/builders/input_reader_builder.py
+++ b/research/object_detection/builders/input_reader_builder.py
@@ -64,13 +64,9 @@ def build(input_reader_config):
         capacity=input_reader_config.queue_capacity,
         min_after_dequeue=input_reader_config.min_after_dequeue)
 
-    label_map_proto_file = None
-    if input_reader_config.HasField('label_map_path'):
-      label_map_proto_file = input_reader_config.label_map_path
     decoder = tf_example_decoder.TfExampleDecoder(
         load_instance_masks=input_reader_config.load_instance_masks,
-        instance_mask_type=input_reader_config.mask_type,
-        label_map_proto_file=label_map_proto_file)
+        instance_mask_type=input_reader_config.mask_type)
     return decoder.decode(string_tensor)
 
   raise ValueError('Unsupported input_reader_config.')

--- a/research/object_detection/builders/input_reader_builder_test.py
+++ b/research/object_detection/builders/input_reader_builder_test.py
@@ -46,7 +46,7 @@ class InputReaderBuilderTest(tf.test.TestCase):
         'image/object/bbox/xmax': dataset_util.float_list_feature([1.0]),
         'image/object/bbox/ymin': dataset_util.float_list_feature([0.0]),
         'image/object/bbox/ymax': dataset_util.float_list_feature([1.0]),
-        'image/object/class/label': dataset_util.int64_list_feature([2]),
+        'image/object/class/label': dataset_util.float_list_feature([0, 1]),
         'image/object/mask': dataset_util.float_list_feature(flat_mask),
     }))
     writer.write(example.SerializeToString())
@@ -76,7 +76,7 @@ class InputReaderBuilderTest(tf.test.TestCase):
     self.assertEquals(
         (4, 5, 3), output_dict[fields.InputDataFields.image].shape)
     self.assertEquals(
-        [2], output_dict[fields.InputDataFields.groundtruth_classes])
+        (0, 1), tuple(output_dict[fields.InputDataFields.groundtruth_classes]))
     self.assertEquals(
         (1, 4), output_dict[fields.InputDataFields.groundtruth_boxes].shape)
     self.assertAllEqual(
@@ -104,7 +104,7 @@ class InputReaderBuilderTest(tf.test.TestCase):
     self.assertEquals(
         (4, 5, 3), output_dict[fields.InputDataFields.image].shape)
     self.assertEquals(
-        [2], output_dict[fields.InputDataFields.groundtruth_classes])
+        (0, 1), tuple(output_dict[fields.InputDataFields.groundtruth_classes]))
     self.assertEquals(
         (1, 4), output_dict[fields.InputDataFields.groundtruth_boxes].shape)
     self.assertAllEqual(

--- a/research/object_detection/inputs_test.py
+++ b/research/object_detection/inputs_test.py
@@ -74,7 +74,7 @@ class InputsTest(test_case.TestCase, parameterized.TestCase):
     model_config = configs['model']
     model_config.faster_rcnn.num_classes = 37
     train_input_fn = inputs.create_train_input_fn(
-        configs['train_config'], configs['train_input_config'], model_config)
+        configs['train_config'], configs['train_input_config'], model_config, one_hot_encoded_labels=False)
     features, labels = _make_initializable_iterator(train_input_fn()).get_next()
 
     self.assertAllEqual([1, None, None, 3],
@@ -113,7 +113,7 @@ class InputsTest(test_case.TestCase, parameterized.TestCase):
     configs['train_config'].retain_original_images = True
     model_config.faster_rcnn.num_classes = 37
     train_input_fn = inputs.create_train_input_fn(
-        configs['train_config'], configs['train_input_config'], model_config)
+        configs['train_config'], configs['train_input_config'], model_config, one_hot_encoded_labels=False)
     features, labels = _make_initializable_iterator(train_input_fn()).get_next()
 
     self.assertAllEqual([1, None, None, 5],
@@ -159,7 +159,7 @@ class InputsTest(test_case.TestCase, parameterized.TestCase):
     eval_config = configs['eval_config']
     eval_config.batch_size = eval_batch_size
     eval_input_fn = inputs.create_eval_input_fn(
-        eval_config, configs['eval_input_configs'][0], model_config)
+        eval_config, configs['eval_input_configs'][0], model_config, one_hot_encoded_labels=False)
     features, labels = _make_initializable_iterator(eval_input_fn()).get_next()
     self.assertAllEqual([eval_batch_size, None, None, 3],
                         features[fields.InputDataFields.image].shape.as_list())
@@ -211,7 +211,7 @@ class InputsTest(test_case.TestCase, parameterized.TestCase):
     model_config.ssd.num_classes = 37
     batch_size = configs['train_config'].batch_size
     train_input_fn = inputs.create_train_input_fn(
-        configs['train_config'], configs['train_input_config'], model_config)
+        configs['train_config'], configs['train_input_config'], model_config, one_hot_encoded_labels=False)
     features, labels = _make_initializable_iterator(train_input_fn()).get_next()
 
     self.assertAllEqual([batch_size, 300, 300, 3],
@@ -255,7 +255,7 @@ class InputsTest(test_case.TestCase, parameterized.TestCase):
     eval_config = configs['eval_config']
     eval_config.batch_size = eval_batch_size
     eval_input_fn = inputs.create_eval_input_fn(
-        eval_config, configs['eval_input_configs'][0], model_config)
+        eval_config, configs['eval_input_configs'][0], model_config, one_hot_encoded_labels=False)
     features, labels = _make_initializable_iterator(eval_input_fn()).get_next()
     self.assertAllEqual([eval_batch_size, 300, 300, 3],
                         features[fields.InputDataFields.image].shape.as_list())
@@ -340,7 +340,7 @@ class InputsTest(test_case.TestCase, parameterized.TestCase):
     train_input_fn = inputs.create_train_input_fn(
         train_config=configs['eval_config'],  # Expecting `TrainConfig`.
         train_input_config=configs['train_input_config'],
-        model_config=configs['model'])
+        model_config=configs['model'], one_hot_encoded_labels=False)
     with self.assertRaises(TypeError):
       train_input_fn()
 
@@ -351,7 +351,7 @@ class InputsTest(test_case.TestCase, parameterized.TestCase):
     train_input_fn = inputs.create_train_input_fn(
         train_config=configs['train_config'],
         train_input_config=configs['model'],  # Expecting `InputReader`.
-        model_config=configs['model'])
+        model_config=configs['model'], one_hot_encoded_labels=False)
     with self.assertRaises(TypeError):
       train_input_fn()
 
@@ -362,7 +362,7 @@ class InputsTest(test_case.TestCase, parameterized.TestCase):
     train_input_fn = inputs.create_train_input_fn(
         train_config=configs['train_config'],
         train_input_config=configs['train_input_config'],
-        model_config=configs['train_config'])  # Expecting `DetectionModel`.
+        model_config=configs['train_config'], one_hot_encoded_labels=False)  # Expecting `DetectionModel`.
     with self.assertRaises(TypeError):
       train_input_fn()
 
@@ -373,7 +373,7 @@ class InputsTest(test_case.TestCase, parameterized.TestCase):
     eval_input_fn = inputs.create_eval_input_fn(
         eval_config=configs['train_config'],  # Expecting `EvalConfig`.
         eval_input_config=configs['eval_input_configs'][0],
-        model_config=configs['model'])
+        model_config=configs['model'], one_hot_encoded_labels=False)
     with self.assertRaises(TypeError):
       eval_input_fn()
 
@@ -384,7 +384,7 @@ class InputsTest(test_case.TestCase, parameterized.TestCase):
     eval_input_fn = inputs.create_eval_input_fn(
         eval_config=configs['eval_config'],
         eval_input_config=configs['model'],  # Expecting `InputReader`.
-        model_config=configs['model'])
+        model_config=configs['model'], one_hot_encoded_labels=False)
     with self.assertRaises(TypeError):
       eval_input_fn()
 
@@ -395,7 +395,7 @@ class InputsTest(test_case.TestCase, parameterized.TestCase):
     eval_input_fn = inputs.create_eval_input_fn(
         eval_config=configs['eval_config'],
         eval_input_config=configs['eval_input_configs'][0],
-        model_config=configs['eval_config'])  # Expecting `DetectionModel`.
+        model_config=configs['eval_config'], one_hot_encoded_labels=False)  # Expecting `DetectionModel`.
     with self.assertRaises(TypeError):
       eval_input_fn()
 
@@ -593,7 +593,7 @@ class DataTransformationFnTest(test_case.TestCase):
         fields.InputDataFields.image_additional_channels:
             tf.constant(additional_channels),
         fields.InputDataFields.groundtruth_classes:
-            tf.constant(np.array([1, 1], np.int32))
+            tf.constant(np.array([1, 1], np.float32))
     }
 
     input_transformation_fn = functools.partial(
@@ -618,7 +618,7 @@ class DataTransformationFnTest(test_case.TestCase):
         fields.InputDataFields.groundtruth_boxes:
             tf.constant(np.array([[0, 0, 1, 1], [.5, .5, 1, 1]], np.float32)),
         fields.InputDataFields.groundtruth_classes:
-            tf.constant(np.array([3, 1], np.int32))
+            tf.constant(np.array([[0, 0, 1], [1, 0, 0]], np.float32).flatten())
     }
     num_classes = 3
     input_transformation_fn = functools.partial(
@@ -636,72 +636,6 @@ class DataTransformationFnTest(test_case.TestCase):
     self.assertAllClose(
         transformed_inputs[fields.InputDataFields.groundtruth_confidences],
         [[0, 0, 1], [1, 0, 0]])
-
-  def test_returns_correct_labels_with_unrecognized_class(self):
-    tensor_dict = {
-        fields.InputDataFields.image:
-            tf.constant(np.random.rand(4, 4, 3).astype(np.float32)),
-        fields.InputDataFields.groundtruth_boxes:
-            tf.constant(
-                np.array([[0, 0, 1, 1], [.2, .2, 4, 4], [.5, .5, 1, 1]],
-                         np.float32)),
-        fields.InputDataFields.groundtruth_area:
-            tf.constant(np.array([.5, .4, .3])),
-        fields.InputDataFields.groundtruth_classes:
-            tf.constant(np.array([3, -1, 1], np.int32)),
-        fields.InputDataFields.groundtruth_keypoints:
-            tf.constant(
-                np.array([[[.1, .1]], [[.2, .2]], [[.5, .5]]],
-                         np.float32)),
-        fields.InputDataFields.groundtruth_keypoint_visibilities:
-            tf.constant([True, False, True]),
-        fields.InputDataFields.groundtruth_instance_masks:
-            tf.constant(np.random.rand(3, 4, 4).astype(np.float32)),
-        fields.InputDataFields.groundtruth_is_crowd:
-            tf.constant([False, True, False]),
-        fields.InputDataFields.groundtruth_difficult:
-            tf.constant(np.array([0, 0, 1], np.int32))
-    }
-
-    num_classes = 3
-    input_transformation_fn = functools.partial(
-        inputs.transform_input_data,
-        model_preprocess_fn=_fake_model_preprocessor_fn,
-        image_resizer_fn=_fake_image_resizer_fn,
-        num_classes=num_classes)
-    with self.test_session() as sess:
-      transformed_inputs = sess.run(
-          input_transformation_fn(tensor_dict=tensor_dict))
-
-    self.assertAllClose(
-        transformed_inputs[fields.InputDataFields.groundtruth_classes],
-        [[0, 0, 1], [1, 0, 0]])
-    self.assertAllEqual(
-        transformed_inputs[fields.InputDataFields.num_groundtruth_boxes], 2)
-    self.assertAllClose(
-        transformed_inputs[fields.InputDataFields.groundtruth_area], [.5, .3])
-    self.assertAllEqual(
-        transformed_inputs[fields.InputDataFields.groundtruth_confidences],
-        [[0, 0, 1], [1, 0, 0]])
-    self.assertAllClose(
-        transformed_inputs[fields.InputDataFields.groundtruth_boxes],
-        [[0, 0, 1, 1], [.5, .5, 1, 1]])
-    self.assertAllClose(
-        transformed_inputs[fields.InputDataFields.groundtruth_keypoints],
-        [[[.1, .1]], [[.5, .5]]])
-    self.assertAllEqual(
-        transformed_inputs[
-            fields.InputDataFields.groundtruth_keypoint_visibilities],
-        [True, True])
-    self.assertAllEqual(
-        transformed_inputs[
-            fields.InputDataFields.groundtruth_instance_masks].shape, [2, 4, 4])
-    self.assertAllEqual(
-        transformed_inputs[fields.InputDataFields.groundtruth_is_crowd],
-        [False, False])
-    self.assertAllEqual(
-        transformed_inputs[fields.InputDataFields.groundtruth_difficult],
-        [0, 1])
 
   def test_returns_correct_merged_boxes(self):
     tensor_dict = {
@@ -710,7 +644,7 @@ class DataTransformationFnTest(test_case.TestCase):
         fields.InputDataFields.groundtruth_boxes:
             tf.constant(np.array([[.5, .5, 1, 1], [.5, .5, 1, 1]], np.float32)),
         fields.InputDataFields.groundtruth_classes:
-            tf.constant(np.array([3, 1], np.int32))
+            tf.constant(np.array([[0, 0, 1], [1, 0, 0]], np.float32).flatten())
     }
 
     num_classes = 3
@@ -744,7 +678,7 @@ class DataTransformationFnTest(test_case.TestCase):
         fields.InputDataFields.groundtruth_boxes:
             tf.constant(np.array([[0, 0, 1, 1], [.5, .5, 1, 1]], np.float32)),
         fields.InputDataFields.groundtruth_classes:
-            tf.constant(np.array([3, 1], np.int32)),
+            tf.constant(np.array([[0, 0, 1], [1, 0, 0]], np.float32).flatten()),
         fields.InputDataFields.groundtruth_confidences:
             tf.constant(np.array([1.0, -1.0], np.float32))
     }
@@ -772,7 +706,7 @@ class DataTransformationFnTest(test_case.TestCase):
         fields.InputDataFields.groundtruth_instance_masks:
             tf.constant(np.random.rand(2, 4, 4).astype(np.float32)),
         fields.InputDataFields.groundtruth_classes:
-            tf.constant(np.array([3, 1], np.int32)),
+            tf.constant(np.array([[0, 0, 1], [1, 0, 0]], np.float32).flatten()),
         fields.InputDataFields.original_image_spatial_shape:
             tf.constant(np.array([4, 4], np.int32))
     }
@@ -813,7 +747,7 @@ class DataTransformationFnTest(test_case.TestCase):
         fields.InputDataFields.image:
             tf.constant(np_image),
         fields.InputDataFields.groundtruth_classes:
-            tf.constant(np.array([3, 1], np.int32))
+            tf.constant(np.array([[0, 0, 1], [1, 0, 0]], np.float32).flatten())
     }
 
     def fake_model_preprocessor_fn(image):
@@ -841,7 +775,7 @@ class DataTransformationFnTest(test_case.TestCase):
         fields.InputDataFields.image:
             tf.constant(np_image),
         fields.InputDataFields.groundtruth_classes:
-            tf.constant(np.array([3, 1], np.int32))
+            tf.constant(np.array([[0, 0, 1, 0], [1, 0, 0, 0]], np.float32).flatten())
     }
 
     def add_one_data_augmentation_fn(tensor_dict):
@@ -862,7 +796,7 @@ class DataTransformationFnTest(test_case.TestCase):
                         np_image + 1)
     self.assertAllEqual(
         augmented_tensor_dict[fields.InputDataFields.groundtruth_classes],
-        [[0, 0, 0, 1], [0, 1, 0, 0]])
+        [[1, 1, 2, 1], [2, 1, 1, 1]])
 
   def test_applies_data_augmentation_fn_before_model_preprocess_fn(self):
     np_image = np.random.randint(256, size=(4, 4, 3))
@@ -870,7 +804,7 @@ class DataTransformationFnTest(test_case.TestCase):
         fields.InputDataFields.image:
             tf.constant(np_image),
         fields.InputDataFields.groundtruth_classes:
-            tf.constant(np.array([3, 1], np.int32))
+            tf.constant(np.array([[0, 0, 1, 0], [1, 0, 0, 0]], np.float32).flatten())
     }
 
     def mul_two_model_preprocessor_fn(image):
@@ -904,7 +838,7 @@ class PadInputDataToStaticShapesFnTest(test_case.TestCase):
         fields.InputDataFields.groundtruth_boxes:
             tf.placeholder(tf.float32, [None, 4]),
         fields.InputDataFields.groundtruth_classes:
-            tf.placeholder(tf.int32, [None, 3]),
+            tf.placeholder(tf.float32, [None, 3]),
         fields.InputDataFields.true_image_shape:
             tf.placeholder(tf.int32, [3]),
         fields.InputDataFields.original_image_spatial_shape:
@@ -937,7 +871,7 @@ class PadInputDataToStaticShapesFnTest(test_case.TestCase):
         fields.InputDataFields.groundtruth_boxes:
             tf.placeholder(tf.float32, [None, 4]),
         fields.InputDataFields.groundtruth_classes:
-            tf.placeholder(tf.int32, [None, 3]),
+            tf.placeholder(tf.float32, [None, 3]),
         fields.InputDataFields.num_groundtruth_boxes:
             tf.placeholder(tf.int32, [])
     }

--- a/research/object_detection/utils/ops_test.py
+++ b/research/object_detection/utils/ops_test.py
@@ -1150,12 +1150,14 @@ class MergeBoxesWithMultipleLabelsTest(tf.test.TestCase):
         [[0.25, 0.25, 0.75, 0.75], [0.0, 0.0, 0.5, 0.75],
          [0.25, 0.25, 0.75, 0.75]],
         dtype=tf.float32)
-    class_indices = tf.constant([0, 4, 2], dtype=tf.int32)
-    class_confidences = tf.constant([0.8, 0.2, 0.1], dtype=tf.float32)
     num_classes = 5
+    class_encodings = tf.one_hot(tf.constant([0, 4, 2], dtype=tf.int32), num_classes)
+    class_confidences = tf.constant([0.8, 0.2, 0.1], dtype=tf.float32)
+    class_confidences = tf.reshape(class_confidences, [-1, 1]) * class_encodings
+
     merged_boxes, merged_classes, merged_confidences, merged_box_indices = (
         ops.merge_boxes_with_multiple_labels(
-            boxes, class_indices, class_confidences, num_classes))
+            boxes, class_encodings, class_confidences, num_classes))
     expected_merged_boxes = np.array(
         [[0.25, 0.25, 0.75, 0.75], [0.0, 0.0, 0.5, 0.75]], dtype=np.float32)
     expected_merged_classes = np.array(
@@ -1178,13 +1180,15 @@ class MergeBoxesWithMultipleLabelsTest(tf.test.TestCase):
         [[0, 0, 1, 1], [0, 1, 1, 1], [1, 0, 1, 1], [1, 1, 1, 1],
          [1, 1, 1, 1], [1, 0, 1, 1], [0, 1, 1, 1], [0, 0, 1, 1]],
         dtype=tf.float32)
-    class_indices = tf.constant([0, 1, 2, 3, 2, 1, 0, 3], dtype=tf.int32)
+    num_classes = 4
+    class_encodings = tf.one_hot(tf.constant([0, 1, 2, 3, 2, 1, 0, 3], dtype=tf.int32), num_classes)
     class_confidences = tf.constant([0.1, 0.9, 0.2, 0.8, 0.3, 0.7, 0.4, 0.6],
                                     dtype=tf.float32)
-    num_classes = 4
+    class_confidences = tf.reshape(class_confidences, [-1, 1]) * class_encodings
+
     merged_boxes, merged_classes, merged_confidences, merged_box_indices = (
         ops.merge_boxes_with_multiple_labels(
-            boxes, class_indices, class_confidences, num_classes))
+            boxes, class_encodings, class_confidences, num_classes))
     expected_merged_boxes = np.array(
         [[0, 0, 1, 1], [0, 1, 1, 1], [1, 0, 1, 1], [1, 1, 1, 1]],
         dtype=np.float32)


### PR DESCRIPTION
Tagging requires to be able to pass multiple labels for the same data-point. We change the example format to directly take the one-hot encoding instead of loading it afterwards.