### PR TITLE
Transform learning rate scheduler steps as percentages

### DIFF
--- a/research/object_detection/model_lib.py
+++ b/research/object_detection/model_lib.py
@@ -354,6 +354,7 @@ def create_model_fn(detection_model_fn, configs, hparams, use_tpu=False,
       # TODO(rathodv): Stop creating optimizer summary vars in EVAL mode once we
       # can write learning rate summaries on TPU without host calls.
       global_step = tf.train.get_or_create_global_step()
+      # TODO: add num_train_steps argument if needed in optimizer_builder tests
       training_optimizer, optimizer_summary_vars = optimizer_builder.build(
           train_config.optimizer)
 

--- a/research/object_detection/protos/optimizer.proto
+++ b/research/object_detection/protos/optimizer.proto
@@ -59,11 +59,11 @@ message ConstantLearningRate {
 //     decaying_the_learning_rate#exponential_decay
 message ExponentialDecayLearningRate {
   optional float initial_learning_rate = 1 [default = 0.002];
-  optional uint32 decay_steps = 2 [default = 4000000];
+  optional float decay_steps_pct = 2 [default = 0.2];
   optional float decay_factor = 3 [default = 0.95];
   optional bool staircase = 4 [default = true];
   optional float burnin_learning_rate = 5 [default = 0.0];
-  optional uint32 burnin_steps =  6 [default = 0];
+  optional float burnin_steps_pct =  6 [default = 0.0];
   optional float min_learning_rate =  7 [default = 0.0];
 }
 
@@ -71,7 +71,7 @@ message ExponentialDecayLearningRate {
 message ManualStepLearningRate {
   optional float initial_learning_rate = 1 [default = 0.002];
   message LearningRateSchedule {
-    optional uint32 step = 1;
+    optional float step_pct = 1;
     optional float learning_rate = 2 [default = 0.002];
   }
   repeated LearningRateSchedule schedule = 2;
@@ -85,8 +85,8 @@ message ManualStepLearningRate {
 // object_detection/utils/learning_schedules.py
 message CosineDecayLearningRate {
   optional float learning_rate_base = 1 [default = 0.002];
-  optional uint32 total_steps = 2 [default = 4000000];
+  optional float total_steps_pct = 2 [default = 1.0];
   optional float warmup_learning_rate = 3 [default = 0.0002];
-  optional uint32 warmup_steps = 4 [default = 10000];
-  optional uint32 hold_base_rate_steps = 5 [default = 0];
+  optional float warmup_steps_pct = 4 [default = 0.1];
+  optional float hold_base_rate_steps_pct = 5 [default = 0.0];
 }


### PR DESCRIPTION
We need to define the scheduler right away, before even knowing the number of steps for the training.

Corner case: when the number of steps is inferior to the number of schedule boundaries, we need to have a strictly increasing step values, and strictly superior to zero. 