### PR TITLE
Normalize raw detection score and remove background score

### DIFF
--- a/research/object_detection/meta_architectures/faster_rcnn_meta_arch.py
+++ b/research/object_detection/meta_architectures/faster_rcnn_meta_arch.py
@@ -1166,7 +1166,7 @@ class FasterRCNNMetaArch(model.DetectionModel):
             fields.DetectionResultFields.raw_detection_boxes:
                 raw_proposal_boxes,
             fields.DetectionResultFields.raw_detection_scores:
-                raw_proposal_scores
+              tf.slice(self._second_stage_score_conversion_fn(raw_proposal_scores), [0, 0, 1], [-1, -1, -1])
         }
 
     # TODO(jrru): Remove mask_predictions from _post_process_box_classifier.
@@ -1673,7 +1673,7 @@ class FasterRCNNMetaArch(model.DetectionModel):
         fields.DetectionResultFields.raw_detection_boxes:
             raw_normalized_detection_boxes,
         fields.DetectionResultFields.raw_detection_scores:
-            class_predictions_with_background_batch
+            tf.slice(class_predictions_with_background_batch_normalized, [0, 0, 1], [-1, -1, -1])
     }
     if nmsed_masks is not None:
       detections[fields.DetectionResultFields.detection_masks] = nmsed_masks

--- a/research/object_detection/meta_architectures/faster_rcnn_meta_arch.py
+++ b/research/object_detection/meta_architectures/faster_rcnn_meta_arch.py
@@ -1166,7 +1166,7 @@ class FasterRCNNMetaArch(model.DetectionModel):
             fields.DetectionResultFields.raw_detection_boxes:
                 raw_proposal_boxes,
             fields.DetectionResultFields.raw_detection_scores:
-              tf.slice(self._second_stage_score_conversion_fn(raw_proposal_scores), [0, 0, 1], [-1, -1, -1])
+                tf.slice(self._second_stage_score_conversion_fn(raw_proposal_scores), [0, 0, 1], [-1, -1, -1])
         }
 
     # TODO(jrru): Remove mask_predictions from _post_process_box_classifier.

--- a/research/object_detection/meta_architectures/faster_rcnn_meta_arch_test_lib.py
+++ b/research/object_detection/meta_architectures/faster_rcnn_meta_arch_test_lib.py
@@ -976,7 +976,7 @@ class FasterRCNNMetaArchTestBase(test_case.TestCase, parameterized.TestCase):
 
     self.assertAllClose(results[4], expected_raw_detection_boxes)
     self.assertAllClose(results[5],
-                        remove_background_class(class_predictions_with_background).reshape([-1, 8, 2]))
+                        remove_background_class(class_predictions_with_background.reshape([-1, 8, num_classes+1])))
     if not use_static_shapes:
       self.assertAllEqual(results[1].shape, [2, 5, 4])
 

--- a/research/object_detection/meta_architectures/faster_rcnn_meta_arch_test_lib.py
+++ b/research/object_detection/meta_architectures/faster_rcnn_meta_arch_test_lib.py
@@ -976,7 +976,7 @@ class FasterRCNNMetaArchTestBase(test_case.TestCase, parameterized.TestCase):
 
     self.assertAllClose(results[4], expected_raw_detection_boxes)
     self.assertAllClose(results[5],
-                        remove_background_class(class_predictions_without_background).reshape([-1, 8, 2]))
+                        remove_background_class(class_predictions_with_background).reshape([-1, 8, 2]))
     if not use_static_shapes:
       self.assertAllEqual(results[1].shape, [2, 5, 4])
 

--- a/research/object_detection/meta_architectures/faster_rcnn_meta_arch_test_lib.py
+++ b/research/object_detection/meta_architectures/faster_rcnn_meta_arch_test_lib.py
@@ -40,6 +40,11 @@ from object_detection.utils import test_utils
 slim = tf.contrib.slim
 BOX_CODE_SIZE = 4
 
+def remove_background_class(scores):
+  """
+  Remove the first colum which is the background score
+  """
+  return np.array(scores)[:, :, 1:]
 
 class FakeFasterRCNNFeatureExtractor(
     faster_rcnn_meta_arch.FasterRCNNFeatureExtractor):
@@ -779,8 +784,9 @@ class FasterRCNNMetaArchTestBase(test_case.TestCase, parameterized.TestCase):
                                     [0.5, 0., 1., 0.5], [0.5, 0.5, 1., 1.]],
                                    [[0., 0., 0.5, 0.5], [0., 0.5, 0.5, 1.],
                                     [0.5, 0., 1., 0.5], [0.5, 0.5, 1., 1.]]]
-    expected_raw_scores = [[[-10., 13.], [10., -10.], [10., -11.], [-10., 12.]],
-                           [[10., -10.], [-10., 13.], [-10., 12.], [10., -11.]]]
+    expected_raw_scores = remove_background_class(
+                            [[[-10., 13.], [10., -10.], [10., -11.], [-10., 12.]],
+                            [[10., -10.], [-10., 13.], [-10., 12.], [10., -11.]]])
 
     self.assertAllClose(results[0], expected_num_proposals)
     for indx, num_proposals in enumerate(expected_num_proposals):
@@ -847,8 +853,10 @@ class FasterRCNNMetaArchTestBase(test_case.TestCase, parameterized.TestCase):
                                     [0.5, 0., 1., 0.5], [0.5, 0.5, 1., 1.]],
                                    [[0., 0., 0.5, 0.5], [0., 0.5, 0.5, 1.],
                                     [0.5, 0., 1., 0.5], [0.5, 0.5, 1., 1.]]]
-    expected_raw_scores = [[[-10., 13.], [-10., 12.], [-10., 11.], [-10., 10.]],
-                           [[-10., 13.], [-10., 12.], [-10., 11.], [-10., 10.]]]
+    expected_raw_scores = remove_background_class(
+                            [[[-10., 13.], [-10., 12.], [-10., 11.], [-10., 10.]],
+                            [[-10., 13.], [-10., 12.], [-10., 11.], [-10., 10.]]])
+
 
     expected_output_keys = set([
         'detection_boxes', 'detection_scores', 'num_detections',
@@ -968,7 +976,7 @@ class FasterRCNNMetaArchTestBase(test_case.TestCase, parameterized.TestCase):
 
     self.assertAllClose(results[4], expected_raw_detection_boxes)
     self.assertAllClose(results[5],
-                        class_predictions_with_background.reshape([-1, 8, 3]))
+                        remove_background_class(class_predictions_without_background).reshape([-1, 8, 2]))
     if not use_static_shapes:
       self.assertAllEqual(results[1].shape, [2, 5, 4])
 

--- a/research/object_detection/meta_architectures/ssd_meta_arch.py
+++ b/research/object_detection/meta_architectures/ssd_meta_arch.py
@@ -720,7 +720,7 @@ class SSDMetaArch(model.DetectionModel):
           fields.DetectionResultFields.raw_detection_boxes:
               tf.squeeze(detection_boxes, axis=2),
           fields.DetectionResultFields.raw_detection_scores:
-              class_predictions
+              detection_scores
       }
       if (nmsed_additional_fields is not None and
           fields.BoxListFields.keypoints in nmsed_additional_fields):

--- a/research/object_detection/meta_architectures/ssd_meta_arch_test.py
+++ b/research/object_detection/meta_architectures/ssd_meta_arch_test.py
@@ -183,8 +183,8 @@ class SsdMetaArchTest(ssd_meta_arch_test_lib.SSDMetaArchTestBase,
                             [0.5, 0., 1., 0.5], [1., 1., 1.5, 1.5]],
                            [[0., 0., 0.5, 0.5], [0., 0.5, 0.5, 1.],
                             [0.5, 0., 1., 0.5], [1., 1., 1.5, 1.5]]]
-    raw_detection_scores = [[[0, 0], [0, 0], [0, 0], [0, 0]],
-                            [[0, 0], [0, 0], [0, 0], [0, 0]]]
+    raw_detection_scores = [[[0], [0], [0], [0]],
+                            [[0], [0], [0], [0]]]
 
     for input_shape in input_shapes:
       tf_graph = tf.Graph()
@@ -311,8 +311,8 @@ class SsdMetaArchTest(ssd_meta_arch_test_lib.SSDMetaArchTestBase,
                             [0.5, 0., 1., 0.5], [1., 1., 1.5, 1.5]],
                            [[0., 0., 0.5, 0.5], [0., 0.5, 0.5, 1.],
                             [0.5, 0., 1., 0.5], [1., 1., 1.5, 1.5]]]
-    raw_detection_scores = [[[0, 0], [0, 0], [0, 0], [0, 0]],
-                            [[0, 0], [0, 0], [0, 0], [0, 0]]]
+    raw_detection_scores = [[[0.5], [0.5], [0.5], [0.5]],
+                            [[0.5], [0.5], [0.5], [0.5]]]
 
     for input_shape in input_shapes:
       tf_graph = tf.Graph()


### PR DESCRIPTION
Related to Deepomatic/thoth#245

We are interested to get all the scores (except the background one), in a normalized format.