### PR TITLE
Relax box normalized coordinates assert of 1.1 to 10.0

### DIFF
--- a/research/object_detection/core/box_list_ops.py
+++ b/research/object_detection/core/box_list_ops.py
@@ -882,7 +882,7 @@ def to_absolute_coordinates(boxlist,
                             height,
                             width,
                             check_range=True,
-                            maximum_normalized_coordinate=10,
+                            maximum_normalized_coordinate=10.0,
                             scope=None):
   """Converts normalized box coordinates to absolute pixel coordinates.
 

--- a/research/object_detection/core/box_list_ops.py
+++ b/research/object_detection/core/box_list_ops.py
@@ -882,7 +882,7 @@ def to_absolute_coordinates(boxlist,
                             height,
                             width,
                             check_range=True,
-                            maximum_normalized_coordinate=1.1,
+                            maximum_normalized_coordinate=10,
                             scope=None):
   """Converts normalized box coordinates to absolute pixel coordinates.
 
@@ -896,7 +896,9 @@ def to_absolute_coordinates(boxlist,
     width: Maximum value for width of absolute box coordinates.
     check_range: If True, checks if the coordinates are normalized or not.
     maximum_normalized_coordinate: Maximum coordinate value to be considered
-      as normalized, default to 1.1.
+      as normalized, default to 10.
+      Note: the original value of 1.1 was too tight and raised an assert for valid normalized boxes
+      with coordinates slightly over 1.1.
     scope: name scope.
 
   Returns:


### PR DESCRIPTION
# Description

https://github.com/Deepomatic/thoth/issues/809

This issue was raised several times on several datasets, at evaluation time. It's not the annotation which is at fault (we checked for that), but the predictions.

Some boxes have normalized coordinates greater than 1.1 and that should not be a problem. So in this pull request we relax this condition.


## Type of change

For a new feature or function, please create an issue first to discuss it
with us before submitting a pull request.

Note: Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] TensorFlow 2 migration
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] A new research paper code implementation
- [ ] Other (Specify)

## Tests

> :memo: Please describe the tests that you ran to verify your changes.
>  
> * Provide instructions so we can reproduce.  
> * Please also list any relevant details for your test configuration.  

**Test Configuration**:

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
