### PR TITLE
Remove tensorflow.contrib dependencies for AutoAugment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,10 @@ RUN cd /tmp && \
     pip install dist/pycocotools-2.0.tar.gz
 
 
+ADD ./requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
+RUN pip install --no-deps tf-models-official==2.4.0  # this would install tf 2.4
+
 ADD research /app
 WORKDIR /app
 
@@ -44,11 +48,6 @@ RUN protoc object_detection/protos/*.proto --python_out=. && \
     cd slim && \
     python setup.py sdist && \
     pip install dist/slim-0.1.tar.gz
-
-ADD ./requirements.txt /tmp/requirements.txt
-RUN pip install -r /tmp/requirements.txt
-RUN pip install --no-deps tf-models-official==2.4.0  # this would install tf 2.4
-
 
 ## Do not use --ignore pytest flag: it will make tests crash. Instead, we remove unwanted files
 RUN py.test object_detection/dataset_tools/create_pascal_tf_record_test.py && \

--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 all:
 	docker build -t tf-models --target base .
-	docker run -v ${ROOT_DIR}/research:/app -ti tf-models bash
+	docker run -v ${ROOT_DIR}/research:/app -w /app -ti tf-models bash

--- a/research/object_detection/core/preprocessor_test.py
+++ b/research/object_detection/core/preprocessor_test.py
@@ -2949,7 +2949,6 @@ class PreprocessorTest(test_case.TestCase, parameterized.TestCase):
     self.assertAllEqual(images_shape, patched_images_shape)
     self.assertAllEqual(images, patched_images)
 
-  @unittest.skipIf(tf_version.is_tf2(), 'Skipping TF1.X only test.')
   def testAutoAugmentImage(self):
     def graph_fn():
       preprocessing_options = []

--- a/research/object_detection/utils/autoaugment_utils.py
+++ b/research/object_detection/utils/autoaugment_utils.py
@@ -30,10 +30,7 @@ try:
 except ImportError:
   # TF 2.0 doesn't ship with contrib, fallback with TFA
   import tensorflow_addons.image as contrib_image
-
 # pylint: enable=g-import-not-at-top
-
-
 
 # This signifies the max integer that the controller RNN could predict for the
 # augmentation scheme.


### PR DESCRIPTION
Needed to fix https://github.com/Deepomatic/thoth/issues/920

AutoAugment uses `tensorflow.contrib` lib, which is not longer here in TF2.x. To do so I:
- replaced the `tensorflow.contrib.training.HParams` object by a simple dict, it works
- use `tensorflow_addons.image` instead of `tensorflow.contrib.image` (which has the same API needed)


Also changed a bit the Makefile to allow a user to enter the docker shell by doing "make", and putting "ADD requirements.txt" earlier to have better caching.


TODO: bump to this commit in Thoth